### PR TITLE
docs: Add pronunciation guide, home network diagram, and improve examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,65 @@ Access services behind NAT without port forwarding.
 
 ## What is IPREF?
 
-IPREF (**IP** addressing with **References**) is a networking protocol that provides direct connectivity between hosts across different address spaces--including private networks behind NAT, overlapping networks, and even across IPv4/IPv6 boundaries. It eliminates the need for traditional NAT port forwarding by using reference-based addressing.
+IPREF (**IP** addressing with **References**, pronounced "I-P-REF") is a networking protocol that provides direct connectivity between hosts across different address spaces--including private networks behind NAT, overlapping networks, and even across IPv4/IPv6 boundaries. It eliminates the need for traditional NAT port forwarding by using reference-based addressing.
+
+**Note:** IPREF should always be written in all capital letters.
 
 Unlike VPNs or mesh networks, IPREF works at the protocol level and is inherently peer-to-peer. Services become accessible automatically once DNS is configured with no manual port forwarding, no complex NAT rules, no firewall exceptions.
 
 **Learn more:** [IETF Draft Specification](https://www.ietf.org/archive/id/draft-augustyn-intarea-ipref-06.html) | [Architecture Details](docs/ARCHITECTURE.md)
+
+## Example Home Network Setup
+
+This diagram shows a typical home network with an IPREF gateway. A single-interface PC behind NAT serves as the gateway, making internal services accessible from the Internet without port forwarding:
+
+```
+    192.168.10.0/24       ┏━━━━━  Public Internet
+            ║             ┃
+            ║             ┃
+            ║    .1 ╭─────┸────╮
+            ╟───────┤ WiFi Rtr │
+            ║       ╰──────────╯
+            ║
+            ║    .5 ┏━━━━━━━━━━┓
+            ╟───────┨ IPREF gw ┃    single interface is OK
+            ║       ┗━━━━━━━━━━┛
+            ║
+            ║       ╭─────────╮
+            ║   .21 │ private │     sample private server with ssh access
+            ╟───────┤ server  │     will be reachable externally via IPREF
+            ║       │  ssh    │
+            ║       ╰─────────╯
+            ║
+            ║       ╭─────────╮
+            ║   .22 │ private │     sample private webserver with https access
+            ╟───────┤ website │     will be reachable externally via IPREF
+            ║       │  https  │
+            ║       ╰─────────╯
+            ║
+            ╟── private computers, laptops, tablets, etc.
+            ║
+            ╟── private devices, phones, printers, etc.
+            ║
+         private
+         network
+```
+
+**Configuration:**
+
+**WiFi Router (192.168.10.1):**
+- Forward UDP port 1045 to `192.168.10.5`
+- Add static route for `10.240.0.0/12` via `192.168.10.5`
+
+**IPREF Gateway (192.168.10.5):**
+- Encode network: `10.240.0.0/12`
+- DNS resolver listening on `192.168.10.5` (accessible to local network)
+
+**Local Computers and Devices:**
+- Option 1: Add nameserver `192.168.10.5` before existing nameservers
+- Option 2 (recommended): Configure your local resolver in the gateway's Corefile, then set `192.168.10.5` as the sole nameserver
+
+**Tip:** Configuring the static route on your WiFi router redirects IPREF traffic at the first hop, eliminating additional routing overhead and the need to configure routes on individual devices.
 
 ## Quick Start
 
@@ -143,18 +197,17 @@ Once you have the gateway running, you can publish services from your local netw
 
 ### Example
 
-To publish `webserver.internal` at `10.0.0.10` as `web.example.com`:
+To publish `web.internal` at `10.0.0.10` as `web.example.com`:
 
 **Internal DNS** (`/etc/coredns/db.internal`):
 ```
-webserver.internal.  IN  A  10.0.0.10
+web.internal.  IN  A  10.0.0.10
 ```
 
 **External DNS** (in your public zone):
 ```
 web.example.com.  IN  TXT  "AA gw.example.com + 1025"
 gw.example.com.   IN  A    YOUR_PUBLIC_IP
-gw.example.com.   IN  TXT  "AA gw.example.com + 1"
 ```
 
 The DNS agent synchronizes these records, and the gateway automatically maps incoming connections for `web.example.com` to `10.0.0.10`.

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -379,7 +379,6 @@ example.com.  IN  NS   ns2
 gw.example.com.      IN  A    203.0.113.5
 
 ; AA records for IPREF addresses
-gw.example.com.      IN  TXT  "AA gw.example.com + 1"
 host11.example.com.  IN  TXT  "AA gw.example.com + 1025"
 host22.example.com.  IN  TXT  "AA gw.example.com + 1026"
 ```

--- a/examples/db.internal
+++ b/examples/db.internal
@@ -27,7 +27,9 @@ gw.internal.           IN  A  10.0.0.1
 ; Published services
 ; These are services that will be accessible via IPREF
 ; The hostname before .internal must match the hostname in external DNS
-webserver.internal.    IN  A  10.0.0.10
+; NOTE: Hostname must match the top segment of the external DNS name
+; e.g., web.internal matches web.example.com
+web.internal.          IN  A  10.0.0.10
 ssh.internal.          IN  A  10.0.0.22
 api.internal.          IN  A  10.0.0.30
 db.internal.           IN  A  10.0.0.40
@@ -37,10 +39,10 @@ db.internal.           IN  A  10.0.0.40
 ; loadbalanced.internal. IN  A  10.0.0.51
 
 ; Example with CNAME
-; www.internal.          IN  CNAME  webserver.internal.
+; www.internal.          IN  CNAME  web.internal.
 
 ; Example with service records
-; _http._tcp.internal.   IN  SRV  0 5 80 webserver.internal.
+; _http._tcp.internal.   IN  SRV  0 5 80 web.internal.
 
 ; DMZ services (if using separate zone)
 ; These would be in a different network segment

--- a/examples/dns-zone.txt
+++ b/examples/dns-zone.txt
@@ -29,16 +29,12 @@ ns2.example.com.  IN  A  203.0.113.11
 ; The gateway must have an A record with its public IP
 gw.example.com.       IN  A    203.0.113.5
 
-; Gateway AA record
-; Reference 1 is reserved for the gateway itself by convention
-gw.example.com.       IN  TXT  "AA gw.example.com + 1"
-
 ; Published services
 ; Use references ≥1025 for security (makes port scanning impractical)
-; The hostname (e.g., "webserver") must match the internal DNS zone
+; The hostname (e.g., "web") must match the internal DNS zone
 
-; Web server (matches webserver.internal -> 10.0.0.10)
-webserver.example.com. IN  TXT  "AA gw.example.com + 1025"
+; Web server (matches web.internal -> 10.0.0.10)
+web.example.com.       IN  TXT  "AA gw.example.com + 1025"
 
 ; SSH server (matches ssh.internal -> 10.0.0.22)
 ssh.example.com.       IN  TXT  "AA gw.example.com + 1026"
@@ -59,7 +55,7 @@ db.example.com.        IN  TXT  "AA gw.example.com + 1028"
 ; service2.example.com.  IN  TXT  "AA gw2.example.com + 2048"
 
 ; CNAME example (points to another IPREF-enabled host)
-; www.example.com.       IN  CNAME  webserver.example.com.
+; www.example.com.       IN  CNAME  web.example.com.
 
 ; Note: You can also add regular A/AAAA records for services
 ; that should be accessible via traditional IP addressing


### PR DESCRIPTION
Improves documentation clarity and usability with visual aids and corrected examples.

- **Pronunciation guide**: Clarify that "IPREF" is pronounced "I-P-REF" (not "eye-pref") and should always be written in capitals
- **Home network diagram**: Add ASCII diagram showing typical single-interface gateway setup behind a WiFi router, including configuration tips for routing and DNS
- **Example corrections**:
  - Remove `gw.example.com` TXT records to discourage hosting services on gw.
  - Fix hostname consistency (`webserver` → `web`) across internal/external DNS examples
  - Add clarifying comments about hostname matching requirements